### PR TITLE
fix: 修复Log4J 的高危漏洞

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.sky-gu</groupId>
     <artifactId>sky-spring-boot-dependencies</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>2.3.7.2</version>
 
     <packaging>pom</packaging>
     <name>sky-spring-boot-dependencies</name>


### PR DESCRIPTION
更新log4j的依赖版本到2.15.0